### PR TITLE
Trivy Fix - Use latest GO Lint V5

### DIFF
--- a/.github/workflows/ci-product.yaml
+++ b/.github/workflows/ci-product.yaml
@@ -2,7 +2,7 @@ name: product-catalog-ci-full
 
 on: 
   pull_request:
-    branches:
+    branches: 
       - main
 
 jobs:


### PR DESCRIPTION
      - name: Golangci-lint
        uses: golangci/golangci-lint-action@v5
        with:
          version: latest